### PR TITLE
修复对象存储里文件夹配置无效的问题

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -15,11 +15,18 @@ var cos = new COS({
 function uploadFile(_config, fromPath, toPath, cb) {
     cos.options.SecretId = globalConfig.cos.secret_id;
     cos.options.SecretKey = globalConfig.cos.secret_key;
+
+    // 桶里的文件夹
+    var cosFolder = globalConfig.cos.folder || '/';
+    if (cosFolder.substr(-1, 1) !== '/') {
+      cosFolder = cosFolder + '/'
+    }
+
     var opt = {
         Bucket: globalConfig.cos.bucket || (globalConfig.cos.bucketname + '-' + globalConfig.cos.appid),
         Region: globalConfig.cos.region,
     };
-    opt.Key = toPath;
+    opt.Key = cosFolder + toPath;
     opt.Body = fs.createReadStream(fromPath);
     opt.ContentLength = fs.statSync(fromPath).size;
     cos.putObject(opt, function (err, data) {


### PR DESCRIPTION
我在本地测试发现指定 配置里对象存储的文件夹无效, 看了一下代码, 发现上传时未加入这个文件夹配置, 只在压缩(lib/compress.js)的地方有使用.