### PR TITLE
添加上传前，文件名中的反斜杠转成正斜杠。

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -26,6 +26,7 @@ function uploadFile(_config, fromPath, toPath, cb) {
         Bucket: globalConfig.cos.bucket || (globalConfig.cos.bucketname + '-' + globalConfig.cos.appid),
         Region: globalConfig.cos.region,
     };
+    toPath=toPath.replace(/\\/g,"/");
     opt.Key = cosFolder + toPath;
     opt.Body = fs.createReadStream(fromPath);
     opt.ContentLength = fs.statSync(fromPath).size;


### PR DESCRIPTION
添加上传前，文件名中的反斜杠转成正斜杠。
这样cos会自动创建目录。
在winows下文件名带目录时反斜杠，上传到cos上会被当做文件名