### PR TITLE
修复压缩上传的域名错误的bug

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -38,7 +38,7 @@ function compress(config, filePath, toPath, cb) {
 		}
 
 		var req;
-        var picURL = 'http://' + config.bucket + '.pic' + config.region + '.myqcloud.com' + folder + toPath + '?imageView2/q/70';
+        var picURL = 'http://' + config.bucket + '.pic.' + config.region + '.myqcloud.com' + folder + toPath + '?imageView2/q/70';
 
 		if(!isOA) {
 			req = request(picURL);


### PR DESCRIPTION
开启压缩的时候，由于域名错误，会导致上传失败

wrong：.picap-guangzhou.myqcloud.com

另外建议添加一个压缩比率参数，默认70%